### PR TITLE
Workaround to current user's configuration failing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
     failed_when: login_as_self.rc is not defined
     when: login_as_self.rc == 0
 
+
   # Run the rest as remote_user
   - block:
     - name: Gather facts, we know the username now
@@ -67,6 +68,17 @@
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
+      when: user.name != ansible_user
+
+    - name: Add user to groups, workaround for current user failing
+      shell: sudo usermod -g {{ user.group }} -G {{ user.groups }} {{ user.name }}
+      with_items:
+       - "{{ adminusers | default([]) }}"
+       - "{{ moreusers | default([]) }}"
+      loop_control:
+        loop_var: user
+        label: "{{ user.name }}"
+      when: user.name == ansible_user
 
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:
@@ -92,7 +104,8 @@
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
-      when: adminremove_passwords
+# Need to exclude current user or otherwise the task fails
+      when: adminremove_passwords and user.name != ansible_user
 
     - name: Add ssh keys and use key_options if option is used
       authorized_key: user="{{user.name}}" key='{{user.pubkey}}' key_options='{{ user.options | default(omit) }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,10 @@
         label: "{{ user.name }}"
       when: user.name != ansible_user
 
+# Ansible user module fails to modify currently logged in user as it is 
+# attempting to modify things that did not really change.
+# Workaround is to run usermod manually for the currently logged in user.
+
     - name: Add user to groups, workaround for current user failing
       shell: sudo usermod -g {{ user.group }} -G {{ user.groups }} {{ user.name }}
       with_items:


### PR DESCRIPTION
Configuring the currently connected user fails with Ansible user
module and therefore implemented workaround to handle current
user with explicit usermod command.