### PR TITLE
Set ssh_extra_args to ssh_args by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,9 +27,10 @@ admin_root_keys: []
 
 adminremove_passwords: False
 # If you need to point to a hard coded config file or otherwise mess with the
-# manual ssh which runs at the start of this role to test whether to use the 
+# manual ssh which runs at the start of this role to test whether to use the
 # default user or root.
-ssh_extra_args: "-F ssh.config -o PasswordAuthentication=no"
+# Defaults to ssh_args from ansible.cfg or empty string if that isn't set/found
+ssh_extra_args: "{{ ssh_args | default('') }}"
 # Create groups from a list
 admin_list_of_groups: []
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,8 +6,10 @@
     become: no # We don't want to run as root here
     check_mode: no
     changed_when: false # This never changes anything
-    failed_when: false # The ssh failure doesn't imply a failure of this role
     register: login_as_self
+    failed_when: # The ssh failure doesn't always imply a failure of this role
+      - "{{ login_as_self | failed }}"
+      - "{{ login_as_self.stderr | search('WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!') }}"
 
   - name: Use bootstrap_user to login if current/configured user failed or if fact checking is disabled
     set_fact:


### PR DESCRIPTION
Change ssh_extra_args so it defaults to ssh_args. Previous behaviour ignored
default or custom Ansible settings forcing users to duplicate their ssh
settings in multiple places.

The previous setting also leaked some CSC specific config file name
which isn't useful.