### PR TITLE
Handle current user when uid is unset

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,8 +88,7 @@
       when:
         # Ansible user module fails to modify any logged in user when uid is set
         # Workaround is to run usermod manually for the currently logged in user.
-        - user.uid is not defined
-        - user.name != ansible_ssh_user
+        - user.uid is not defined or (user.uid is defined and user.name == ansible_ssh_user)
 
     - name: command usermod - ansible_ssh_user primary group and extra groups, workaround for current user failing
       command: sudo usermod -g {{ user.group }} -G {{ user.groups }} {{ user.name }}


### PR DESCRIPTION
Previous change had a bug which was hard to test. When using
bootstrap_user we noticed that changes weren't getting deployed.